### PR TITLE
add missing openssl headers

### DIFF
--- a/tac_plus-ng/main.c
+++ b/tac_plus-ng/main.c
@@ -54,6 +54,7 @@
 #endif
 
 #ifdef WITH_SSL
+#include <openssl/x509v3.h>
 #include <openssl/err.h>
 #endif
 


### PR DESCRIPTION
Without including the openssl/x509v3 headers compiling will fail due to not finding the used symbols (example: X509_PURPOSE_SSL_CLIENT)

Not sure if I missing something. Without the include I wasn't able to compile it.