### PR TITLE
Use a raw string in the regex for username validation (mavis.py)

### DIFF
--- a/mavis/python/mavis.py
+++ b/mavis/python/mavis.py
@@ -127,7 +127,7 @@ class Mavis:
 			self.write(MAVIS_FINAL, AV_V_RESULT_ERROR, "User not set.")
 			return False
 
-		if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
+		if re.match(r'\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
 			self.write(MAVIS_FINAL, AV_V_RESULT_ERROR, "Username not valid.")
 			return False
 


### PR DESCRIPTION
This PR updates the regular expression used to ensure backslashes are treated literally and correctly match special characters (, ), |, &, =, and *.

This will also resolve the warning messages when using python mavis modules:
```
/usr/local/lib/mavis/mavis_tacplus_demo.py: 47: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 47:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
/usr/local/lib/mavis/mavis_tacplus_demo.py: 51: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 51:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
/usr/local/lib/mavis/mavis_tacplus_demo.py: 53: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 53:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
/usr/local/lib/mavis/mavis_tacplus_demo.py: 90: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 90:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
/usr/local/lib/mavis/mavis_tacplus_demo.py: 93: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 93:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
/usr/local/lib/mavis/mavis_tacplus_demo.py: 49: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 49:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
/usr/local/lib/mavis/mavis_tacplus_demo.py: 91: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 91:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
/usr/local/lib/mavis/mavis_tacplus_demo.py: 92: /usr/local/lib/mavis/mavis.py:129: SyntaxWarning: invalid escape sequence '\('
/usr/local/lib/mavis/mavis_tacplus_demo.py: 92:   if re.match('\(|\)|,|\||&|=|\*', self.av_pairs[AV_A_USER]):
```