### PR TITLE
Fix the null reference vulnerability.

### DIFF
--- a/tac_plus-ng/mavis.c
+++ b/tac_plus-ng/mavis.c
@@ -350,7 +350,7 @@ static void mavis_lookup_final(tac_session *session, av_ctx *avc)
 	    }
 	}
 
-	if (u->dynamic)
+	if (u && u->dynamic)
 	    u->dynamic = io_now.tv_sec + r->caching_period;
 
 	session->passwd_mustchange = av_get(avc, AV_A_PASSWORD_MUSTCHANGE) ? 1 : 0;


### PR DESCRIPTION
Hello,
Our team has recently been conducting research on a null-pointer-dereference (NPD) vulnerability detection tool and used it to scan event-driven-servers(the version on the master branch). After a manual review, we have identified some potentially vulnerable code snippets that may lead to null-pointer-dereference bugs. 
The NULL Dereference vulnerability happens in `static void mavis_lookup_final（)`, `tac_plus-ng/mavis.c`
How the NULL Pointer Dereference happens:
1. When `u == NULL`  and `r->mavis_userdb != TRISTATE_YES`. 
2. Dereference of NULL variable `u` in `u->dynamic`. 
```
static void mavis_lookup_final(tac_session *session, av_ctx *avc)
{
    ......
    tac_user *u = lookup_user(session);

=>  if (u) // u == NULL
        r = u->realm;
  
=>  if ((r->mavis_userdb == TRISTATE_YES) && (!u || u->dynamic)) {
        ......
    }

=>  if (u->dynamic)
        u->dynamic = io_now.tv_sec + r->caching_period;
    ......
}

```