### PR TITLE
Enable posix group membership lookups in ldap

### DIFF
--- a/doc/tac_plus-ng.html
+++ b/doc/tac_plus-ng.html
@@ -3514,6 +3514,13 @@ int async 1
 </td>
 </tr>
 <tr>
+<td><tt class="literal">LDAP_FILTER_POSIXGROUP</tt></td>
+<td>
+<p>LDAP search filter for posix groups. Default:</p>
+<p><tt class="literal">"(&amp;(objectclass=posixGroup)(memberUid=%s))"</tt></p>
+</td>
+</tr>
+<tr>
 <td><tt class="literal">LDAP_USER</tt></td>
 <td>
 <p>User to use for LDAP bind if server doesn't permit anonymous searches.</p>
@@ -3584,6 +3591,13 @@ int async 1
 <td><tt class="literal">LDAP_NESTED_GROUP_DEPTH</tt></td>
 <td>
 <p>Limit nested group lookups to the given value. Unlimited if unset.</p>
+<p>Example: <tt class="literal">1</tt></p>
+</td>
+</tr>
+<tr>
+<td><tt class="literal">LDAP_POSIXGROUP</tt></td>
+<td>
+<p>Also lookup for posix group memberships if enabled.</p>
 <p>Example: <tt class="literal">1</tt></p>
 </td>
 </tr>

--- a/doc/tac_plus-ng.txt
+++ b/doc/tac_plus-ng.txt
@@ -2893,6 +2893,11 @@ int async 1
    LDAP search filter for groups. Default:
 
    "(&(objectclass=groupOfNames)(member=%s))"
+   LDAP_FILTER_POSIXGROUP
+
+   LDAP search filter for posix groups. Default:
+
+   "(&(objectclass=posixGroup)(memberUid=%s))"
    LDAP_USER
 
    User to use for LDAP bind if server doesn't permit anonymous
@@ -2948,6 +2953,11 @@ int async 1
 
    Limit nested group lookups to the given value. Unlimited if
    unset.
+
+   Example: 1
+   LDAP_POSIXGROUP
+
+   Also lookup for posix group memberships if enabled.
 
    Example: 1
      __________________________________________________________


### PR DESCRIPTION
On some openldap systems group memberships are based on posixgroups. Sure a migration to groupOfNames can be done or planned, but it's easier to support posixgroups until every ldap directory and structure has been updated (which often takes time and coordination with other parties using the directory.

I've added the group membership lookup to the perl script first, the `mt` version should be added as well, but I wanted to hear your point first. Since posixGroups in the old RFC2307 (not RFC2307bis) don't support nested groups, we can skip this stop for the moment.