### PR TITLE
Fix certificate time check in accept_control_tls()

### DIFF
--- a/tac_plus-ng/main.c
+++ b/tac_plus-ng/main.c
@@ -943,8 +943,8 @@ static void accept_control_tls(struct context *ctx, int cur)
 		if (notafter_asn1 && notbefore_asn1) {
 		    struct tm notafter_tm, notbefore_tm;
 		    if ((1 == ASN1_TIME_to_tm(notafter_asn1, &notafter_tm)) && (1 == ASN1_TIME_to_tm(notbefore_asn1, &notbefore_tm))) {
-			notafter = mktime(&notafter_tm);
-			notbefore = mktime(&notbefore_tm);
+			notafter = timegm(&notafter_tm);
+			notbefore = timegm(&notbefore_tm);
 		    }
 
 		    if (notafter > -1 && notbefore > -1) {


### PR DESCRIPTION
The notbefore/notafter time in the certificate are in UTC, so we should use timegm instead of mktime.

This bug was discovered while we are testing our TACACS+ TLS client code with the latest tac_plus-ng. This fixes the problem, otherwise we see the following:

218: 09:37:07.398 0/00000000: - Version ab4b5d2594e21984aa35a30bfc7a069cd430c2b4 initialized
218: 09:37:07.422 0/00000000: - TLSv1.3 connection request from 127.0.0.1 to 127.0.0.1 port 62227 (realm: default) rejected (error:0A000126:SSL routines::unexpected eof while reading) [accept_control_tls:837]
218: 09:37:13.292 0/00000000: - TLSv1.3 connection request from 127.0.0.1 to 127.0.0.1 port 62227 (realm: default) rejected (cert not yet valid) [accept_control_tls:957]