### PR TITLE
fix: address buffer overflow and overread in mavis

### DIFF
--- a/mavis/groups.c
+++ b/mavis/groups.c
@@ -93,7 +93,7 @@ char *groups_getlist(char *name, gid_t gid, char *buf, size_t buflen)
 	    return buf;
 	if (i)
 	    *b++ = ',', l++;
-	j = snprintf(b, (size_t) (b + buflen - b), "%d", g[i]);
+	j = snprintf(b, (size_t) (buf + buflen - b), "%d", g[i]);
 	l += j;
 	if (l >= buflen)
 	    break;

--- a/mavis/mavis_parse.c
+++ b/mavis/mavis_parse.c
@@ -314,7 +314,7 @@ static void substitute_envvar(struct sym *sym)
 	    char *ve = vs;
 	    while (*ve && *ve != '}')
 		ve++;
-	    if (ve) {
+	    if (*ve) {
 		size_t var_len = ve - vs + 1;
 		char var[var_len];
 		memcpy(var, vs, var_len);


### PR DESCRIPTION
- groups.c: fix snprintf buffer size argument (b + buflen - b) -> (buf + buflen - b) to correctly calculate remaining buffer space
- mavis_parse.c: check *ve instead of ve to prevent buffer overread on unclosed ${VAR