### PR TITLE
fix: prevent unsigned integer underflow in size comparisons

### DIFF
--- a/mavis/libmavis_tacauth_limit.c
+++ b/mavis/libmavis_tacauth_limit.c
@@ -64,7 +64,7 @@ static int mavis_init_in(mavis_ctx * mcx)
 	pid_t pid;
 	struct stat st;
 	size_t dirlen = strlen(mcx->hashdir);
-	while (dirlen - 1 > 0 && mcx->hashdir[dirlen - 1] == '/')
+	while (dirlen > 1 && mcx->hashdir[dirlen - 1] == '/')
 	    dirlen--;
 	mcx->hashdir[dirlen] = 0;
 

--- a/mavis/libmavis_tacinfo_cache.c
+++ b/mavis/libmavis_tacinfo_cache.c
@@ -62,7 +62,7 @@ static int mavis_init_in(mavis_ctx * mcx)
 	pid_t pid;
 	struct stat st;
 	size_t dirlen = strlen(mcx->hashdir);
-	while (dirlen - 1 > 0 && mcx->hashdir[dirlen - 1] == '/')
+	while (dirlen > 1 && mcx->hashdir[dirlen - 1] == '/')
 	    dirlen--;
 	mcx->hashdir[dirlen] = 0;
 

--- a/tac_plus-ng/authen.c
+++ b/tac_plus-ng/authen.c
@@ -691,7 +691,7 @@ static void do_chap(tac_session *session)
     enum hint_enum hint = hint_nosuchuser;
 
     char *resp = NULL;
-    if (session->authen_data->data_len - MD5_LEN > 0) {
+    if (session->authen_data->data_len > MD5_LEN) {
 	session->chap_pppid = session->authen_data->data[0];
 	session->chap_challenge = session->authen_data->data + 1;
 	session->chap_challenge_len = session->authen_data->data_len - 1 - MD5_LEN;

--- a/tac_plus/authen.c
+++ b/tac_plus/authen.c
@@ -440,7 +440,7 @@ static void do_chap(tac_session *session)
 	    if (session->passwdp->passwd[PW_CHAP]->type != S_clear) {
 		hint = hint_no_cleartext;
 		res = TAC_PLUS_AUTHEN_STATUS_FAIL;
-	    } else if (session->authen_data->data_len - MD5_LEN > 0) {
+	    } else if (session->authen_data->data_len > MD5_LEN) {
 		u_char digest[MD5_LEN];
 		myMD5_CTX mdcontext;
 


### PR DESCRIPTION
Rewrite unsigned subtraction comparisons to avoid wraparound:
- tac_plus-ng/authen.c, tac_plus/authen.c: CHAP data_len - MD5_LEN > 0 wraps when data_len < MD5_LEN, bypassing the guard and causing OOB read from a malformed network packet
- libmavis_tacinfo_cache.c, libmavis_tacauth_limit.c: dirlen - 1 > 0 wraps when dirlen == 0 (empty hashdir config), causing OOB read