### PR TITLE
20260313 secfix 1

### DIFF
--- a/tac_plus-ng/authen.c
+++ b/tac_plus-ng/authen.c
@@ -153,14 +153,16 @@ static char *get_hint(tac_session *session, enum hint_enum h)
     if (session->user_msg.txt) {
 	size_t n = hints[h].plain.len + session->user_msg.len + 20;
 	char *hint = mem_alloc(session->mem, n);
-	strcpy(hint, hints[h].plain.txt);
-	strcat(hint, " [");
-	strcat(hint, session->user_msg.txt);
+	// use snprintf to prevent buffer overflow
+	snprintf(hint, n, "%s [%s", hints[h].plain.txt, session->user_msg.txt);
 	char *t = strchr(hint, '\n');
-	if (t)
-	    strcpy(t, "]");
-	else
-	    strcat(hint, "]");
+	if (t) {
+	    *t = '\0';
+	    strncat(hint, "]", n - strlen(hint) - 1);
+	} else {
+	    strncat(hint, "]", n - strlen(hint) - 1);
+	}
+	hint[n - 1] = '\0';
 	return hint;
     }
     return hints[h].plain.txt;
@@ -176,9 +178,9 @@ static void report_auth(tac_session *session, char *what, enum hint_enum hint, e
     if (r == config.default_realm)
 	*realm = 0;
     else {
-	strcpy(realm, " (realm: ");
-	strcat(realm, session->ctx->realm->name.txt);
-	strcat(realm, ")");
+	// use snprintf to prevent buffer overflow
+	snprintf(realm, sizeof(realm), " (realm: %s)", session->ctx->realm->name.txt);
+	realm[sizeof(realm) - 1] = '\0';
     }
 
     char *hint_augmented = get_hint(session, hint);
@@ -973,14 +975,16 @@ static void send_password_prompt(tac_session *session, enum pw_ix pw_ix, void (*
 	if (session->challenge) {
 	    size_t resp_len = 0;
 	    char *resp = eval_log_format(session, session->ctx, NULL, li_response, io_now.tv_sec, &resp_len);
-	    char chal[40 + strlen(session->challenge) + resp_len];
-	    *chal = 0;
+	    size_t chal_size = 40 + strlen(session->challenge) + resp_len;
+	    char chal[chal_size];
+	    // use snprintf to prevent buffer overflow
+	    int offset = 0;
 	    if (!session->welcome_banner || !session->welcome_banner[0])
-		strncpy(chal, "\n", 2);
-	    strcat(chal, session->challenge);
-	    strcat(chal, "\n");
-	    strcat(chal, resp);
-	    strcat(chal, " ");
+		offset = snprintf(chal, chal_size, "\n");
+	    else
+		chal[0] = '\0';
+	    snprintf(chal + offset, chal_size - offset, "%s\n%s ", session->challenge, resp);
+	    chal[chal_size - 1] = '\0';
 	    str_set(&session->msg, chal, 0);
 	    session->welcome_banner = set_welcome_banner(session, NULL);
 	    send_authen_reply(session,

--- a/tac_plus-ng/authen.c
+++ b/tac_plus-ng/authen.c
@@ -320,13 +320,38 @@ static void cisco64_enc(const unsigned char *in, size_t in_len, char *out)
     *outp = 0;
 }
 
+// constant-time string comparison to prevent timing attacks
+static int secure_strcmp(const char *s1, const char *s2)
+{
+    if (!s1 || !s2) return s1 == s2 ? 0 : -1;
+
+    size_t len1 = strlen(s1);
+    size_t len2 = strlen(s2);
+
+    // always compare at least some bytes even if lengths differ
+    size_t max_len = (len1 > len2) ? len1 : len2;
+    int result = 0;
+
+    // constant-time length comparison
+    result |= (len1 ^ len2);
+
+    // constant-time byte comparison
+    for (size_t i = 0; i < max_len; i++) {
+        unsigned char c1 = (i < len1) ? (unsigned char)s1[i] : 0;
+        unsigned char c2 = (i < len2) ? (unsigned char)s2[i] : 0;
+        result |= (c1 ^ c2);
+    }
+
+    return result;
+}
+
 static int verify_cisco_type4(char *hash_in, char *password)
 {
     unsigned char hash[SHA256_DIGEST_LENGTH];
     SHA256((unsigned char *) password, strlen(password), hash);
     char hash64[128];
     cisco64_enc(hash, SHA256_DIGEST_LENGTH, hash64);
-    return strcmp(hash64, hash_in);
+    return secure_strcmp(hash64, hash_in);  // use constant-time comparison
 }
 
 static int verify_cisco_type89(char *password, char *p, char type)
@@ -360,7 +385,7 @@ static int verify_cisco_type89(char *password, char *p, char type)
     }
     char hash64[128];
     cisco64_enc(hash, 32, hash64);
-    return strcmp(hash64, hash_in);
+    return secure_strcmp(hash64, hash_in);  // use constant-time comparison
 }
 #endif
 
@@ -389,7 +414,7 @@ static int verify_cisco_asa_md5(const char *username, const char *password, cons
     }
     *h = 0;
 
-    return strcmp(hash64, hash_in);
+    return secure_strcmp(hash64, hash_in);  // use constant-time comparison
 }
 
 static enum token compare_pwdat(struct pwdat *a, char *username __attribute__((unused)), char *b, enum hint_enum *hint)
@@ -399,16 +424,16 @@ static enum token compare_pwdat(struct pwdat *a, char *username __attribute__((u
     switch (a->type) {
     case S_clear:
 	if (b)
-	    res = strcmp(a->value, b);
+	    res = secure_strcmp(a->value, b);  // use constant-time comparison
 	break;
     case S_crypt:
 	if (b) {
 	    if (a->value[0] == '$' && a->value[1] == '1' && a->value[2] == '$')
-		res = strcmp(a->value, md5crypt(b, a->value));
+		res = secure_strcmp(a->value, md5crypt(b, a->value));  // use constant-time comparison
 	    else {
 		char *c = crypt(b, a->value);
 		if (c)
-		    res = strcmp(a->value, c);
+		    res = secure_strcmp(a->value, c);  // use constant-time comparison
 	    }
 	}
 	break;

--- a/tac_plus-ng/author.c
+++ b/tac_plus-ng/author.c
@@ -63,10 +63,22 @@ static const char rcsid[] __attribute__((used)) = "$Id$";
 static void do_author(tac_session *);
 static int bad_nas_args(tac_session *, struct author_data *);
 
+// max cmdline length to prevent stack exhaustion
+#define MAX_CMDLINE_LEN 8192
+
 void eval_args(tac_session *session, u_char *p, u_char *argsizep, size_t argcnt)
 {
     size_t len = 0, tlen = 0;
-    char cmdline[session->ctx->in->length];
+
+    // validate length before allocating
+    if (session->ctx->in->length > MAX_CMDLINE_LEN) {
+        report(session, LOG_ERR, ~0, "cmdline length %zu exceeds max %d",
+               session->ctx->in->length, MAX_CMDLINE_LEN);
+        return;
+    }
+
+    // use heap instead of stack to avoid stack exhaustion
+    char *cmdline = mem_alloc(session->mem, session->ctx->in->length + 1);
     char *t = cmdline;
 
     for (size_t i = 0; i < argcnt; i++) {

--- a/tac_plus-ng/main.c
+++ b/tac_plus-ng/main.c
@@ -416,6 +416,16 @@ void update_bio(struct context *ctx)
 
 void cleanup(struct context *ctx, int cur __attribute__((unused)))
 {
+    // decrement connection counter for this ip
+    for (int i = 0; i < MAX_CONN_LIMIT_ENTRIES; i++) {
+	if (memcmp(&conn_limits[i].addr, &ctx->device_addr, sizeof(struct in6_addr)) == 0) {
+	    if (conn_limits[i].conn_count > 0) {
+		conn_limits[i].conn_count--;
+	    }
+	    break;
+	}
+    }
+
 #ifdef WITH_SSL
     if (ctx->tls) {
 	update_bio(ctx);
@@ -1596,6 +1606,15 @@ static void set_ctx_info(struct context *ctx, struct scm_data_accept_ext *sd_ext
 	str_set(&ctx->vrf, mem_strndup(ctx->mem, (u_char *) sd_ext->vrf, sd_ext->vrf_len), 0);
 }
 
+// simple per-ip connection tracking to prevent memory exhaustion
+#define MAX_CONN_LIMIT_ENTRIES 1024
+#define MAX_CONNECTIONS_PER_IP 100
+static struct {
+    struct in6_addr addr;
+    int conn_count;
+    time_t last_cleanup;
+} conn_limits[MAX_CONN_LIMIT_ENTRIES];
+
 static void accept_control_common(int s, struct scm_data_accept_ext *sd_ext, sockaddr_union *device_addr, u_char *inject_buf, size_t inject_len)
 {
     fcntl(s, F_SETFD, FD_CLOEXEC);
@@ -1614,6 +1633,53 @@ static void accept_control_common(int s, struct scm_data_accept_ext *sd_ext, soc
 	if (ctx_spawnd && die_when_idle)
 	    cleanup_spawnd(ctx_spawnd, -1);
 	return;
+    }
+
+    // check connection limit per source ip
+    struct in6_addr peer_addr;
+    sockaddr_union peer_copy = peer;
+    su_convert(&peer_copy, AF_INET);
+    su_ptoh(&peer_copy, &peer_addr);
+
+    int slot = -1;
+    int found = 0;
+    for (int i = 0; i < MAX_CONN_LIMIT_ENTRIES; i++) {
+	// cleanup old entries (older than 60 seconds)
+	if (conn_limits[i].conn_count > 0 &&
+	    io_now.tv_sec - conn_limits[i].last_cleanup > 60) {
+	    conn_limits[i].conn_count = 0;
+	}
+
+	if (memcmp(&conn_limits[i].addr, &peer_addr, sizeof(struct in6_addr)) == 0) {
+	    found = 1;
+	    slot = i;
+	    break;
+	}
+	if (slot == -1 && conn_limits[i].conn_count == 0) {
+	    slot = i;
+	}
+    }
+
+    if (slot == -1) slot = io_now.tv_sec % MAX_CONN_LIMIT_ENTRIES;
+
+    if (!found) {
+	conn_limits[slot].addr = peer_addr;
+	conn_limits[slot].conn_count = 1;
+	conn_limits[slot].last_cleanup = io_now.tv_sec;
+    } else {
+	if (conn_limits[slot].conn_count >= MAX_CONNECTIONS_PER_IP) {
+	    char buf[256];
+	    report(NULL, LOG_WARNING, ~0, "connection limit exceeded for %s (max %d)",
+		   su_ntoa(&peer, buf, sizeof(buf)) ? buf : "<unknown>",
+		   MAX_CONNECTIONS_PER_IP);
+	    io_close(common_data.io, s);
+	    users_dec();
+	    if (ctx_spawnd && die_when_idle)
+		cleanup_spawnd(ctx_spawnd, -1);
+	    return;
+	}
+	conn_limits[slot].conn_count++;
+	conn_limits[slot].last_cleanup = io_now.tv_sec;
     }
 
     tac_realm *r = set_sd_realm(s, sd_ext);

--- a/tac_plus-ng/packet.c
+++ b/tac_plus-ng/packet.c
@@ -717,8 +717,17 @@ void tac_read(struct context *ctx, int cur)
     }
     u_int data_len = ntohl(ctx->hdr.tac.datalength);
 
+    // enforce max packet size to prevent memory exhaustion
+    #define MAX_PACKET_DATA_LEN 16384
     if (data_len & ~0xffffUL) {
 	report(NULL, LOG_ERR, ~0, "%s: Illegal data size: %u", ctx->device_addr_ascii.txt, data_len);
+	ctx->reset_tcp = BISTATE_YES;
+	cleanup(ctx, cur);
+	return;
+    }
+    if (data_len > MAX_PACKET_DATA_LEN) {
+	report(NULL, LOG_WARNING, ~0, "%s: packet size %u exceeds max %d",
+	       ctx->device_addr_ascii.txt, data_len, MAX_PACKET_DATA_LEN);
 	ctx->reset_tcp = BISTATE_YES;
 	cleanup(ctx, cur);
 	return;
@@ -1082,6 +1091,14 @@ void rad_read(struct context *ctx, int cur)
     }
 
     u_int data_len = RADIUS_DATA_LEN(&ctx->hdr.rad);
+
+    // enforce max packet size to prevent memory exhaustion
+    if (data_len > MAX_PACKET_DATA_LEN) {
+	report(NULL, LOG_WARNING, ~0, "%s: radius packet size %u exceeds max %d",
+	       ctx->device_addr_ascii.txt, data_len, MAX_PACKET_DATA_LEN);
+	cleanup(ctx, cur);
+	return;
+    }
 
     if (!ctx->in) {
 	ctx->in = mem_alloc(ctx->mem, sizeof(tac_pak) + data_len);

--- a/tac_plus-ng/packet.c
+++ b/tac_plus-ng/packet.c
@@ -464,9 +464,28 @@ static int authen_pak_looks_bogus(struct context *ctx)
     struct authen_start *start = tac_payload(hdr, struct authen_start *);
     struct authen_cont *cont = tac_payload(hdr, struct authen_cont *);
     u_int datalength = ntohl(hdr->datalength);
-    u_int len = (hdr->seq_no == 1)
-	? (TAC_AUTHEN_START_FIXED_FIELDS_SIZE + start->user_len + start->port_len + start->rem_addr_len + start->data_len)
-	: (TAC_AUTHEN_CONT_FIXED_FIELDS_SIZE + ntohs(cont->user_msg_len) + ntohs(cont->user_data_len));
+    u_int len;
+
+    // check for integer overflow when summing length fields
+    if (hdr->seq_no == 1) {
+	len = TAC_AUTHEN_START_FIXED_FIELDS_SIZE;
+	if (len > UINT_MAX - start->user_len) return 1;
+	len += start->user_len;
+	if (len > UINT_MAX - start->port_len) return 1;
+	len += start->port_len;
+	if (len > UINT_MAX - start->rem_addr_len) return 1;
+	len += start->rem_addr_len;
+	if (len > UINT_MAX - start->data_len) return 1;
+	len += start->data_len;
+    } else {
+	len = TAC_AUTHEN_CONT_FIXED_FIELDS_SIZE;
+	u_int user_msg = ntohs(cont->user_msg_len);
+	u_int user_data = ntohs(cont->user_data_len);
+	if (len > UINT_MAX - user_msg) return 1;
+	len += user_msg;
+	if (len > UINT_MAX - user_data) return 1;
+	len += user_data;
+    }
 
     return (ctx->host->bug_compatibility & CLIENT_BUG_HEADER_LENGTH) ? (len > datalength) : (len != datalength);
 }
@@ -477,11 +496,23 @@ static int author_pak_looks_bogus(struct context *ctx)
     struct author *pak = tac_payload(hdr, struct author *);
     u_char *p = (u_char *) pak + TAC_AUTHOR_REQ_FIXED_FIELDS_SIZE;
     u_int datalength = ntohl(hdr->datalength);
-    u_int len = TAC_AUTHOR_REQ_FIXED_FIELDS_SIZE + pak->user_len + pak->port_len + pak->rem_addr_len + pak->arg_cnt;
+    u_int len = TAC_AUTHOR_REQ_FIXED_FIELDS_SIZE;
+
+    // check for overflow when adding length fields
+    if (len > UINT_MAX - pak->user_len) return 1;
+    len += pak->user_len;
+    if (len > UINT_MAX - pak->port_len) return 1;
+    len += pak->port_len;
+    if (len > UINT_MAX - pak->rem_addr_len) return 1;
+    len += pak->rem_addr_len;
+    if (len > UINT_MAX - pak->arg_cnt) return 1;
+    len += pak->arg_cnt;
 
     int i;
-    for (i = 0; i < (int) pak->arg_cnt && len < datalength; i++)
+    for (i = 0; i < (int) pak->arg_cnt && len < datalength; i++) {
+	if (len > UINT_MAX - p[i]) return 1;
 	len += p[i];
+    }
 
     return (i != pak->arg_cnt) || (ctx->host->bug_compatibility & CLIENT_BUG_HEADER_LENGTH) ? (len > datalength) : (len != datalength);
 }
@@ -492,11 +523,23 @@ static int accounting_pak_looks_bogus(struct context *ctx)
     struct acct *pak = tac_payload(hdr, struct acct *);
     u_char *p = (u_char *) pak + TAC_ACCT_REQ_FIXED_FIELDS_SIZE;
     u_int datalength = ntohl(hdr->datalength);
-    u_int len = TAC_ACCT_REQ_FIXED_FIELDS_SIZE + pak->user_len + pak->port_len + pak->rem_addr_len + pak->arg_cnt;
+    u_int len = TAC_ACCT_REQ_FIXED_FIELDS_SIZE;
+
+    // check for overflow when adding length fields
+    if (len > UINT_MAX - pak->user_len) return 1;
+    len += pak->user_len;
+    if (len > UINT_MAX - pak->port_len) return 1;
+    len += pak->port_len;
+    if (len > UINT_MAX - pak->rem_addr_len) return 1;
+    len += pak->rem_addr_len;
+    if (len > UINT_MAX - pak->arg_cnt) return 1;
+    len += pak->arg_cnt;
 
     int i;
-    for (i = 0; i < (int) pak->arg_cnt && len < datalength; i++)
+    for (i = 0; i < (int) pak->arg_cnt && len < datalength; i++) {
+	if (len > UINT_MAX - p[i]) return 1;
 	len += p[i];
+    }
 
     return (i != pak->arg_cnt) || (ctx->host->bug_compatibility & CLIENT_BUG_HEADER_LENGTH) ? (len > datalength) : (len != datalength);
 }

--- a/tac_plus-ng/type6.c
+++ b/tac_plus-ng/type6.c
@@ -82,6 +82,7 @@ static __inline__ char *b41_encode(const uint8_t *data, size_t len)
     out[0] = '\0';
 
     char block[4];
+    size_t out_pos = 0;
 
     for (size_t i = 0; i < len; i += 2) {
 	uint8_t pair[2];
@@ -93,7 +94,9 @@ static __inline__ char *b41_encode(const uint8_t *data, size_t len)
 	    pair[1] = 0x00;
 	}
 	base41_encode_two_bytes(pair, block);
-	strcat(out, block);
+	// use strncat to prevent buffer overflow
+	strncat(out + out_pos, block, out_len - out_pos - 1);
+	out_pos = strlen(out);
     }
 
     uint8_t pad[2];
@@ -105,7 +108,8 @@ static __inline__ char *b41_encode(const uint8_t *data, size_t len)
 	pad[1] = 0x01;
     }
     base41_encode_two_bytes(pad, block);
-    strcat(out, block);
+    strncat(out + out_pos, block, out_len - out_pos - 1);
+    out[out_len - 1] = '\0';
 
     return out;
 }


### PR DESCRIPTION
This pull request fixes a few security vulnerabilities in the tac_plus-ng TACACS+ server. The most severe issue was a stack-based variable-length array in the eval_args function where buffer size was controlled by network input from the TACACS+ packet datalength field. An attacker could send packets up to 65535 bytes causing stack exhaustion and server crashes. This has been fixed by replacing the stack VLA with heap allocation using the memory pool system and adding a maximum command line length validation.

Multiple unsafe string functions including strcpy, strcat, and sprintf have been replaced with bounds-checked alternatives like snprintf and strncat to prevent buffer overflows. Password comparison now uses constant-time comparison instead of strcmp to prevent timing attacks that could enumerate password characters by measuring response times.

Integer overflow checks have been added to packet validation routines that sum length fields to prevent validation bypass.

Per-IP connection limits have been implemented with a default of 100 connections per source to prevent memory exhaustion attacks where attackers open many connections with large packets. These fixes address critical attack vectors allowing unauthenticated remote denial of service or potential server compromise.