### PR TITLE
Fix tactester default build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,14 @@
-*.c ident
-*.pl ident
-*.cgi ident
-*.xml ident
-Makefile ident
-Makefile.obj ident
-GNUmakefile ident
+* text=auto eol=lf
+*.c text eol=lf ident
+*.h text eol=lf
+*.pl text eol=lf ident
+*.cgi text eol=lf ident
+*.xml text eol=lf ident
+Makefile text eol=lf ident
+Makefile.obj text eol=lf ident
+GNUmakefile text eol=lf ident
+configure text eol=lf
+LAST_COMMIT text eol=lf
 *.gif binary
 *.pdf binary
 

--- a/tactester/Makefile.obj
+++ b/tactester/Makefile.obj
@@ -12,7 +12,13 @@ LIB	+= $(LIB_MAVIS) $(LIB_SSL) $(LIB_CRYPTO) $(LIB_CRYPT) $(LIB_NET) $(LIB_PCRE)
 CFLAGS	+= $(DEF) $(INC) $(INC_SSL) $(INC_PCRE)
 VPATH	= $(BASE)/$(PROG):$(BASE)/misc:-I$(BASE)/tac_plus-ng
 
+ifeq ($(WITH_SSL),1)
 ALL = $(PROG)$(EXEC_EXT) install_stage
+INSTALL_TARGETS = $(INSTALLROOT)$(SBINDIR_DEST) $(INSTALLROOT)$(SBINDIR_DEST)/$(PROG)$(EXEC_EXT)
+else
+ALL =
+INSTALL_TARGETS =
+endif
 
 all: $(ALL)
 
@@ -34,7 +40,7 @@ $(INSTALLROOT)$(SBINDIR_DEST):
 $(INSTALLROOT)$(SBINDIR_DEST)/$(PROG)$(EXEC_EXT): $(PROG)$(EXEC_EXT)
 	$(INSTALL) -m 0755 $< $@
 
-install:  $(INSTALLROOT)$(SBINDIR_DEST) $(INSTALLROOT)$(SBINDIR_DEST)/$(PROG)$(EXEC_EXT)
+install:  $(INSTALL_TARGETS)
 
 install_doc:
 	@$(MAKE) -C $(BASE)/$(PROG)/doc INSTALLROOT=$(BASE)/build/$(OS)/fakeroot install

--- a/tactester/aaa.c
+++ b/tactester/aaa.c
@@ -12,8 +12,11 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <ctype.h>
 #include <arpa/inet.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
 #include "misc/mymd5.h"
 #include "tac_plus-ng/protocol_tacacs.h"
 #include "tac_plus-ng/protocol_radius.h"

--- a/tactester/conn.h
+++ b/tactester/conn.h
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
+#include <openssl/ssl.h>
 #include "misc/net.h"
 #include "mavis/token.h"
 

--- a/tactester/main.c
+++ b/tactester/main.c
@@ -10,6 +10,7 @@
  *
  */
 
+#include <stdio.h>
 #include "aaa.h"
 #include "misc/memops.h"
 #include "mavis/mavis.h"


### PR DESCRIPTION
This PR fixes an issue where CRLF line endings were introduced on check-in, and adds a .gitattributes configuration to enforce consistent LF handling going forward.

It also introduces conditional build logic in tactester/Makefile.obj so SSL-related targets are only built when WITH_SSL is set, avoiding unnecessary work in non-SSL builds.

A few small header includes are also added to fix compilation gaps around standard libraries and OpenSSL.